### PR TITLE
Fix for memory issues caused by incorrect size of certain classes in C++ code

### DIFF
--- a/QtAdMobBannerIos.h
+++ b/QtAdMobBannerIos.h
@@ -84,6 +84,8 @@ private:
     QPoint m_Position;
 #if defined(__OBJC__)
     __unsafe_unretained QtAdMobBannerDelegate* m_AdMob;
+#else
+    void* m_AdMob;
 #endif
     enum LoadingState
     {

--- a/QtAdMobInterstitialIos.h
+++ b/QtAdMobInterstitialIos.h
@@ -58,6 +58,8 @@ private:
     QString m_UnitId;
 #if defined(__OBJC__)
     __unsafe_unretained QtAdMobInterstitialDelegate* m_AdMob;
+#else
+    void* m_AdMob;
 #endif
     bool m_IsNeedToShow;
 };


### PR DESCRIPTION
This should fix #24 #17 #13 #12 and other iOS-related crashes.