### PR TITLE
Added qml rewarded video

### DIFF
--- a/QtAdMob.pri
+++ b/QtAdMob.pri
@@ -13,6 +13,7 @@ SOURCES += \
     $$PWD/QtAdMobBannerDummy.cpp \
     $$PWD/QtAdMobInterstitialAndroid.cpp \
     $$PWD/QtAdMobInterstitialDummy.cpp \
+    $$PWD/QtAdMobRewardedVideo.cpp \
     $$PWD/QtAdmobBanner.cpp \
     $$PWD/QtAdmobInterstitial.cpp
 
@@ -30,7 +31,8 @@ HEADERS  += \
     $$PWD/QtAdMobInterstitial.h \
     $$PWD/QtAdMobInterstitialIos.h \
     $$PWD/QtAdMobInterstitialAndroid.h \
-    $$PWD/QtAdMobInterstitialDummy.h
+    $$PWD/QtAdMobInterstitialDummy.h \
+    $$PWD/QtAdMobRewardedVideo.h
 
 ios {
     ios:QMAKE_CXXFLAGS += -fobjc-arc
@@ -69,3 +71,4 @@ android {
     export(copydata.commands)
     android:QMAKE_EXTRA_TARGETS += first copydata
 }
+

--- a/QtAdMobRewardedVideo.cpp
+++ b/QtAdMobRewardedVideo.cpp
@@ -1,0 +1,182 @@
+#include "QtAdMobRewardedVideo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef Q_OS_ANDROID
+// Listener when Java calls Rewarded() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_Rewarded(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling Rewarded signal
+    emit QmlRewardedVideoAd::Instances()->rewarded();
+}
+// Listener when Java calls RewardedVideoAdClosed() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoAdClosed(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoAdClosed signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoAdClosed();
+}
+// Listener when Java calls RewardedVideoAdFailedToLoad() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoAdFailedToLoad(JNIEnv *env, jobject thiz, jint errorCode)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoAdFailedToLoad signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoAdFailedToLoad(errorCode);
+}
+// Listener when Java calls RewardedVideoAdLeftApplication() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoAdLeftApplication(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoAdLeftApplication signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoAdLeftApplication();
+}
+// Listener when Java calls RewardedVideoAdLoaded() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoAdLoaded(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoAdLoaded signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoAdLoaded();
+}
+// Listener when Java calls RewardedVideoAdOpened() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoAdOpened(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoAdOpened signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoAdOpened();
+}
+// Listener when Java calls RewardedVideoCompleted() signal
+JNIEXPORT void JNICALL Java_com_gmail_manhcuong5993_QtAdMobActivity_RewardedVideoCompleted(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoCompleted signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoCompleted();
+}
+// Listener when Java calls RewardedVideoStarted() signal
+JNIEXPORT void JNICALL Java_org_dreamdev_QtAdMob_QtAdMobActivity_RewardedVideoStarted(JNIEnv *env, jobject thiz)
+{
+    Q_UNUSED(env)
+    Q_UNUSED(thiz)
+
+    // Emit to QML app by calling RewardedVideoStarted signal
+    emit QmlRewardedVideoAd::Instances()->rewardedVideoStarted();
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+// Global variable to keep instance of class
+static QtAdMobRewardedVideoAndroid *mQmlRewardedVideoAd = nullptr;
+
+QtAdMobRewardedVideoAndroid::QtAdMobRewardedVideoAndroid()
+{
+#ifdef Q_OS_ANDROID
+    // Update global instance
+    mQmlRewardedVideoAd = this;
+
+    // Create Android Activity on Qt
+    QPlatformNativeInterface* interface = QGuiApplication::platformNativeInterface();
+    jobject activity = (jobject)interface->nativeResourceForIntegration("QtActivity");
+    if (activity)
+    {
+        m_Activity = new QAndroidJniObject(activity);
+    }
+
+    // Call InitializeBanner method of Java
+    m_Activity->callMethod<void>("InitializeRewardedVideoAd");
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+    m_QtAdmobRewardVideo = new QtAdmobRewardVideoDelegateImpl();
+    m_QtAdmobRewardVideo->setQtAdmobRewardVideoIos(this);
+#endif
+}
+
+QtAdMobRewardedVideoAndroid *QtAdMobRewardedVideoAndroid::Instances()
+{
+    return mQmlRewardedVideoAd;
+}
+
+void QtAdMobRewardedVideoAndroid::setUnitId(const QString &unitId)
+{
+#ifdef Q_OS_ANDROID
+    if(m_Activity != nullptr)
+    {
+        QAndroidJniObject param1 = QAndroidJniObject::fromString(unitId);
+        // Call SetBannerUnitId method of Java
+        m_Activity->callMethod<void>("SetRewardedVideoAdUnitId", "(Ljava/lang/String;)V", param1.object<jstring>());
+    }
+#elif _WIN32
+    Q_UNUSED(unitId)
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+   m_QtAdmobRewardVideo->setUnitId(unitId);
+#endif
+}
+
+void QtAdMobRewardedVideoAndroid::setTestDeviceId(const QString &testDeviceId)
+{
+#ifdef Q_OS_ANDROID
+    if(m_Activity != nullptr)
+    {
+        QAndroidJniObject param1 = QAndroidJniObject::fromString(testDeviceId);
+        // Call SetBannerUnitId method of Java
+        m_Activity->callMethod<void>("SetRewardedVideoTestDeviceId", "(Ljava/lang/String;)V", param1.object<jstring>());
+    }
+#elif _WIN32
+    Q_UNUSED(testDeviceId)
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+   m_QtAdmobRewardVideo->setTestDeviceId(testDeviceId);
+#endif
+}
+
+void QtAdMobRewardedVideoAndroid::loadRewardedVideoAd()
+{
+#ifdef Q_OS_ANDROID
+    if(m_Activity != nullptr)
+    {
+        // Call LoadBanner method of Java
+        m_Activity->callMethod<void>("LoadRewardedVideoAd");
+    }
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+   m_QtAdmobRewardVideo->loadRewardedVideoAd();
+#endif
+}
+
+void QtAdMobRewardedVideoAndroid::show()
+{
+#ifdef Q_OS_ANDROID
+    if(m_Activity != nullptr)
+    {
+        // Call LoadBanner method of Java
+        m_Activity->callMethod<void>("ShowRewardedVideoAd");
+    }
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+   m_QtAdmobRewardVideo->show();
+#endif
+}

--- a/QtAdMobRewardedVideo.h
+++ b/QtAdMobRewardedVideo.h
@@ -1,0 +1,53 @@
+#ifndef QMLREWARDEDVIDEOAD_H
+#define QMLREWARDEDVIDEOAD_H
+
+#include <QObject>
+#include <QGuiApplication>
+#ifdef Q_OS_ANDROID
+#include <QAndroidJniObject>
+#include <QtAndroid>
+#include <qpa/qplatformnativeinterface.h>
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+class QtAdmobRewardVideoDelegateImpl;
+#endif
+
+class QtAdMobRewardedVideoAndroid : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString unitId WRITE setUnitId)
+    Q_PROPERTY(QString testDeviceId WRITE setTestDeviceId)
+public:
+    QtAdMobRewardedVideoAndroid();
+    static QtAdMobRewardedVideoAndroid* Instances();
+
+    static void DeclareQML();
+    void setUnitId(const QString& unitId);
+    void setTestDeviceId(const QString &testDeviceId);
+
+signals:
+    void rewarded();
+    void rewardedVideoAdClosed();
+    void rewardedVideoAdFailedToLoad(int errorCode);
+    void rewardedVideoAdLeftApplication();
+    void rewardedVideoAdLoaded();
+    void rewardedVideoAdOpened();
+    void rewardedVideoCompleted();
+    void rewardedVideoStarted();
+
+public slots:
+    void loadRewardedVideoAd();
+    void show();
+
+private:
+#ifdef Q_OS_ANDROID
+    QAndroidJniObject* m_Activity;
+#endif
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+    QtAdmobRewardVideoDelegateImpl* m_QtAdmobRewardVideo;
+#endif
+};
+
+#endif // QMLREWARDEDVIDEOAD_H


### PR DESCRIPTION
`int main(int argc, char *argv[])
{
    QGuiApplication app(argc, argv);

    QmlAdMobBanner::DeclareQML();			// <== Call it before loading qml
    QmlAdMobInterstitial::DeclareQML();		// <== Call it before loading qml
    qmlRegisterType<QtAdMobRewardedVideoAndroid>("QtAdMobRewardedVideo", 1, 0, "QmlRewardedVideoAd"); // <== Call it before loading qml

    QQmlApplicationEngine engine;
    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

    return app.exec();
}`
In qml file import com.dreamdev.QtAdMobRewardedVideo for rewarded video support
`import com.dreamdev.QtAdMobRewardedVideo 1.0`

`QmlRewardedVideoAd
    {
        id: video_ad

        unitId: "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx"
        testDeviceId: ""

        onRewarded: {}
        onRewardedVideoAdClosed: {}
        onRewardedVideoAdFailedToLoad: {}
        onRewardedVideoAdLeftApplication: {}
        onRewardedVideoAdLoaded: {}
        onRewardedVideoAdOpened: {}
        onRewardedVideoCompleted: {}
        onRewardedVideoStarted: {}

        Component.onCompleted: {}
    }
}
`