### PR TITLE
Fix QtAdMobActivity.java is always overwritten

### DIFF
--- a/QtAdMob.pri
+++ b/QtAdMob.pri
@@ -59,8 +59,7 @@ ios {
 android {
     android:QT += androidextras gui-private
 
-    !exists($$ANDROID_PACKAGE_SOURCE_DIR/src/org/dreamdev/QtAdMob)
-    {
+    !exists($$ANDROID_PACKAGE_SOURCE_DIR/src/org/dreamdev/QtAdMob) {
         copydata.commands += $(COPY_DIR) $$shell_path($$PWD/platform/android/src) $$shell_path($$ANDROID_PACKAGE_SOURCE_DIR)
     }
 


### PR DESCRIPTION
Hello.
It looks like condition and opening brace should be on the same line, otherwise the condition will always be met